### PR TITLE
Add support for merging metadata from formatting params

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: go
 
 go:
-  - 1.6.3
-  - 1.7
+  - 1.8.x
+  - 1.9.x
 
 install:
   - export PATH=${PATH}:${HOME}/gopath/bin

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: go
 go:
   - 1.8.x
   - 1.9.x
+  - "1.10.x"
 
 install:
   - export PATH=${PATH}:${HOME}/gopath/bin

--- a/event_test.go
+++ b/event_test.go
@@ -1,0 +1,45 @@
+package slog
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEventfFormatsParams(t *testing.T) {
+	e := Eventf(CriticalSeverity, nil, "foo: %s", "bar")
+	assert.Equal(t, "foo: bar", e.Message)
+}
+
+func TestEventfNilContext(t *testing.T) {
+	e := Eventf(CriticalSeverity, nil, "foo: %s", "bar")
+	assert.NotNil(t, "foo: bar", e.Context)
+}
+
+func TestEventfMetadataParam(t *testing.T) {
+	metadata := map[string]string{
+		"foo": "foo",
+	}
+
+	param := map[string]string{
+		"bar": "bar",
+	}
+
+	e := Eventf(CriticalSeverity, nil, "foo: %v", param, metadata)
+	assert.EqualValues(t, metadata, e.Metadata)
+}
+
+type testLogMetadataProvider map[string]string
+
+func (p testLogMetadataProvider) LogMetadata() map[string]string {
+	return p
+}
+
+func TestEventfLogMetadataProvider(t *testing.T) {
+	param := testLogMetadataProvider{
+		"foo": "bar",
+	}
+
+	e := Eventf(CriticalSeverity, nil, "foo: %v", param)
+	assert.EqualValues(t, param, e.Metadata)
+}


### PR DESCRIPTION
Within our codebase it is common to slog an error using code of the following form:

```
slog.Error(ctx, "Error performing foo: %v", err, slogParams)
```

Often the error contains useful debugging information in its terror params but these don't make it into the slog event. This encourages stuffing that data into the terror message which makes it more challenging to work with programatically.

This change introduces a `logMetadataProvider` interface, any param that satisfies this interface will automatically have the metadata merged into the slog event metadata.