### PR TITLE
Capture non-string metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,40 @@ slog is a library for capturing structured log information. In contrast to "trad
 * captures arbitrary key-value metadata on each log event
 
 slog forwards messages to [`log`](https://golang.org/pkg/log/) by default. But you probably want to write a a custom output to make use of the context and metadata. At [Monzo](https://monzo.com/), slog captures events both on a per-service and a per-request basis (using the context information) and sends them to a centralised logging system. This lets us view all the logs for a given request across all the micro-services it touches.
+
+## Usage
+
+Internally at Monzo, we recommend that users always prefer structured logging where possible. An example of using slog for this would be:
+
+```go
+slog.Info(ctx, "Loading widget", map[string]interface{}{
+    "stage": "reticulating splines",
+})
+```
+
+When logging an error, we recommend attaching the actual error in the "error" key:
+
+```go
+err := errors.New("No splines to reticulate")
+slog.Error(ctx, "Failed to load widget", map[string]interface{}{
+    "error": err,
+})
+```
+
+This lets allows for interoperability with other systems (e.g. one which also forwards errors to an error tracking system) without losing context. `slog` also provides a shorthand for capturing this case in the form of:
+
+```go
+err := errors.New("No splines to reticulate")
+slog.Error(ctx, "Failed to load widget", err)
+```
+
+### Other uses
+
+For backwards-compatibility, slog accepts metadata in the form of `map[string]string`.
+
+It also accepts format parameters in the style of `Printf`:
+
+```go
+stage := "reticulating splines"
+slog.Info(ctx, "Loading widget at stage: %s", stage)
+```

--- a/README.md
+++ b/README.md
@@ -18,17 +18,6 @@ slog.Info(ctx, "Loading widget", map[string]interface{}{
 })
 ```
 
-When logging an error, we recommend attaching the actual error in the "error" key:
-
-```go
-err := errors.New("No splines to reticulate")
-slog.Error(ctx, "Failed to load widget", map[string]interface{}{
-    "error": err,
-})
-```
-
-This lets allows for interoperability with other systems (e.g. one which also forwards errors to an error tracking system) without losing context.
-
 ### Other uses
 
 For backwards-compatibility, slog accepts metadata in the form of `map[string]string`.

--- a/README.md
+++ b/README.md
@@ -27,12 +27,7 @@ slog.Error(ctx, "Failed to load widget", map[string]interface{}{
 })
 ```
 
-This lets allows for interoperability with other systems (e.g. one which also forwards errors to an error tracking system) without losing context. `slog` also provides a shorthand for capturing this case in the form of:
-
-```go
-err := errors.New("No splines to reticulate")
-slog.Error(ctx, "Failed to load widget", err)
-```
+This lets allows for interoperability with other systems (e.g. one which also forwards errors to an error tracking system) without losing context.
 
 ### Other uses
 

--- a/event.go
+++ b/event.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/nu7hatch/gouuid"
+	uuid "github.com/nu7hatch/gouuid"
 )
 
 type Severity int
@@ -37,6 +37,10 @@ func (s Severity) String() string {
 	}
 }
 
+type logMetadataProvider interface {
+	LogMetadata() map[string]string
+}
+
 // An Event is a discrete logging event
 type Event struct {
 	Context   context.Context `json:"-"`
@@ -46,6 +50,9 @@ type Event struct {
 	Message   string          `json:"message"`
 	// Metadata are structured key-value pairs which describe the event.
 	Metadata map[string]string `json:"meta,omitempty"`
+	// RawMetadata is metadata before it has been transformed to string form.
+	// Metadata and RawMetadata will always contain the same keys.
+	RawMetadata map[string]interface{} `json:"rawMeta,omitempty"`
 	// Labels, like Metadata, are key-value pairs which describe the event. Unlike Metadata, these are intended to be
 	// indexed.
 	Labels map[string]string `json:"labels,omitempty"`
@@ -57,7 +64,7 @@ func (e Event) String() string {
 }
 
 // Eventf constructs an event from the given message string and formatting operands. Optionally, event metadata
-// (map[string]string) can be provided as a final argument.
+// (map[string]interface{}, or map[string]string) can be provided as a final argument.
 func Eventf(sev Severity, ctx context.Context, msg string, params ...interface{}) Event {
 	if ctx == nil {
 		ctx = context.Background()
@@ -68,9 +75,22 @@ func Eventf(sev Severity, ctx context.Context, msg string, params ...interface{}
 		return Event{}
 	}
 
+	rawMetadata := map[string]interface{}(nil)
 	metadata := map[string]string(nil)
 	if len(params) > 0 {
+
 		fmtOperands := countFmtOperands(msg)
+
+		// Catch the special error case for Event(..., "Something happened", err).
+		// We explicitly don't process Event(..., "Something happened: %v", err) this way, as
+		// then intentions are not the same, and we don't want to take an opinion on whether to
+		// remove the format argument in this case.
+		if len(params) == 1 && fmtOperands == 0 {
+			errParam, ok := params[0].(error)
+			if ok {
+				return createErrorEvent(ctx, sev, id, msg, errParam)
+			}
+		}
 
 		// If we have been provided with more params than we have formatting arguments
 		// then the last param should be a metadata map
@@ -81,6 +101,23 @@ func Eventf(sev Severity, ctx context.Context, msg string, params ...interface{}
 			if metadataParam, ok := metadataParam.(map[string]string); ok {
 				// Note: we merge the metadata here to avoid mutating the map
 				metadata = mergeMetadata(metadata, metadataParam)
+				// To maintain the invariant that Metadata contains the stringified version of RawMetadata
+				// we copy all values in RawMetadata too. This isn't very efficient, but the invariant is
+				// important for consumers of RawMetadata.
+				rawMetadata = make(map[string]interface{}, len(metadata))
+				for k, v := range metadata {
+					rawMetadata[k] = v
+				}
+			}
+
+			// Check for 'raw' metadata rather than strings, and convert to string form if found.
+			if metadataParam, ok := metadataParam.(map[string]interface{}); ok {
+				rawMetadata = mergeRawMetadata(rawMetadata, metadataParam)
+
+				metadata = make(map[string]string, len(rawMetadata))
+				for k, v := range rawMetadata {
+					metadata[k] = fmt.Sprint(v)
+				}
 			}
 		}
 
@@ -102,16 +139,30 @@ func Eventf(sev Severity, ctx context.Context, msg string, params ...interface{}
 	}
 
 	return Event{
+		Context:     ctx,
+		Id:          id.String(),
+		Timestamp:   time.Now().UTC(),
+		Severity:    sev,
+		Message:     msg,
+		Metadata:    metadata,
+		RawMetadata: rawMetadata,
+	}
+}
+
+func createErrorEvent(ctx context.Context, sev Severity, id *uuid.UUID, msg string, err error) Event {
+	return Event{
 		Context:   ctx,
 		Id:        id.String(),
 		Timestamp: time.Now().UTC(),
 		Severity:  sev,
 		Message:   msg,
-		Metadata:  metadata}
-}
-
-type logMetadataProvider interface {
-	LogMetadata() map[string]string
+		Metadata: map[string]string{
+			"error": err.Error(),
+		},
+		RawMetadata: map[string]interface{}{
+			"error": err,
+		},
+	}
 }
 
 // mergeMetadata merges the metadata but preserves existing entries
@@ -122,6 +173,25 @@ func mergeMetadata(current, new map[string]string) map[string]string {
 
 	if current == nil {
 		current = map[string]string{}
+	}
+
+	for k, v := range new {
+		if _, ok := current[k]; !ok {
+			current[k] = v
+		}
+	}
+
+	return current
+}
+
+// mergeRawMetadata merges the metadata but preserves existing entries
+func mergeRawMetadata(current, new map[string]interface{}) map[string]interface{} {
+	if len(new) == 0 {
+		return current
+	}
+
+	if current == nil {
+		current = map[string]interface{}{}
 	}
 
 	for k, v := range new {

--- a/event.go
+++ b/event.go
@@ -81,17 +81,6 @@ func Eventf(sev Severity, ctx context.Context, msg string, params ...interface{}
 
 		fmtOperands := countFmtOperands(msg)
 
-		// Catch the special error case for Event(..., "Something happened", err).
-		// We explicitly don't process Event(..., "Something happened: %v", err) this way, as
-		// then intentions are not the same, and we don't want to take an opinion on whether to
-		// remove the format argument in this case.
-		if len(params) == 1 && fmtOperands == 0 {
-			errParam, ok := params[0].(error)
-			if ok {
-				return createErrorEvent(ctx, sev, id, msg, errParam)
-			}
-		}
-
 		// If we have been provided with more params than we have formatting arguments
 		// then the last param should be a metadata map
 		if len(params) > fmtOperands {

--- a/event.go
+++ b/event.go
@@ -122,7 +122,7 @@ func Eventf(sev Severity, ctx context.Context, msg string, params ...interface{}
 }
 
 func stringMapToInterfaceMap(m map[string]string) map[string]interface{} {
-	shim := map[string]interface{}{}
+	shim := make(map[string]interface{}, len(m))
 	for k, v := range m {
 		shim[k] = v
 	}

--- a/event_test.go
+++ b/event_test.go
@@ -28,7 +28,22 @@ func TestEventfMetadataParam(t *testing.T) {
 	}
 
 	e := Eventf(CriticalSeverity, nil, "foo: %v", param, metadata)
-	assert.EqualValues(t, metadata, e.Metadata)
+	expected := map[string]interface{}{
+		"foo": "foo",
+	}
+	assert.EqualValues(t, expected, e.Metadata)
+}
+
+func TestEventfMetadataParamInterface(t *testing.T) {
+	metadata := map[string]interface{}{
+		"foo": 3,
+	}
+
+	e := Eventf(CriticalSeverity, nil, "foo", metadata)
+	expected := map[string]interface{}{
+		"foo": 3,
+	}
+	assert.EqualValues(t, expected, e.Metadata)
 }
 
 type testLogMetadataProvider map[string]string
@@ -43,7 +58,10 @@ func TestEventfLogMetadataProvider(t *testing.T) {
 	}
 
 	e := Eventf(CriticalSeverity, nil, "foo: %v", param)
-	assert.EqualValues(t, param, e.Metadata)
+	expected := map[string]interface{}{
+		"foo": "bar",
+	}
+	assert.EqualValues(t, expected, e.Metadata)
 }
 
 func BenchmarkLogMetadataInterface(b *testing.B) {

--- a/event_test.go
+++ b/event_test.go
@@ -1,7 +1,6 @@
 package slog
 
 import (
-	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -45,26 +44,6 @@ func TestEventRawMetadata(t *testing.T) {
 	assert.Equal(t, map[string]string{
 		"error": assert.AnError.Error(),
 	}, e.Metadata)
-}
-
-func TestEventSpecialErrorCase(t *testing.T) {
-	e := Eventf(ErrorSeverity, nil, "Eaten by a grue", assert.AnError)
-
-	assert.Equal(t, "Eaten by a grue", e.Message)
-	assert.Equal(t, map[string]string{
-		"error": assert.AnError.Error(),
-	}, e.Metadata)
-
-	assert.Equal(t, map[string]interface{}{
-		"error": assert.AnError,
-	}, e.RawMetadata)
-}
-
-func TestEventSpecialErrorCaseWithFormat(t *testing.T) {
-	e := Eventf(ErrorSeverity, nil, "game over: %v", errors.New("eaten by a grue"))
-
-	assert.Equal(t, "game over: eaten by a grue", e.Message)
-	assert.Equal(t, map[string]string(nil), e.Metadata)
 }
 
 type testLogMetadataProvider map[string]string

--- a/event_test.go
+++ b/event_test.go
@@ -1,6 +1,7 @@
 package slog
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -29,6 +30,41 @@ func TestEventfMetadataParam(t *testing.T) {
 
 	e := Eventf(CriticalSeverity, nil, "foo: %v", param, metadata)
 	assert.EqualValues(t, metadata, e.Metadata)
+	assert.EqualValues(t, map[string]interface{}{
+		"foo": "foo",
+	}, e.RawMetadata)
+}
+
+func TestEventRawMetadata(t *testing.T) {
+	metadata := map[string]interface{}{
+		"error": assert.AnError,
+	}
+	e := Eventf(CriticalSeverity, nil, "msg", metadata)
+
+	assert.Equal(t, metadata, e.RawMetadata)
+	assert.Equal(t, map[string]string{
+		"error": assert.AnError.Error(),
+	}, e.Metadata)
+}
+
+func TestEventSpecialErrorCase(t *testing.T) {
+	e := Eventf(ErrorSeverity, nil, "Eaten by a grue", assert.AnError)
+
+	assert.Equal(t, "Eaten by a grue", e.Message)
+	assert.Equal(t, map[string]string{
+		"error": assert.AnError.Error(),
+	}, e.Metadata)
+
+	assert.Equal(t, map[string]interface{}{
+		"error": assert.AnError,
+	}, e.RawMetadata)
+}
+
+func TestEventSpecialErrorCaseWithFormat(t *testing.T) {
+	e := Eventf(ErrorSeverity, nil, "game over: %v", errors.New("eaten by a grue"))
+
+	assert.Equal(t, "game over: eaten by a grue", e.Message)
+	assert.Equal(t, map[string]string(nil), e.Metadata)
 }
 
 type testLogMetadataProvider map[string]string

--- a/event_test.go
+++ b/event_test.go
@@ -29,21 +29,6 @@ func TestEventfMetadataParam(t *testing.T) {
 
 	e := Eventf(CriticalSeverity, nil, "foo: %v", param, metadata)
 	assert.EqualValues(t, metadata, e.Metadata)
-	assert.EqualValues(t, map[string]interface{}{
-		"foo": "foo",
-	}, e.RawMetadata)
-}
-
-func TestEventRawMetadata(t *testing.T) {
-	metadata := map[string]interface{}{
-		"error": assert.AnError,
-	}
-	e := Eventf(CriticalSeverity, nil, "msg", metadata)
-
-	assert.Equal(t, metadata, e.RawMetadata)
-	assert.Equal(t, map[string]string{
-		"error": assert.AnError.Error(),
-	}, e.Metadata)
 }
 
 type testLogMetadataProvider map[string]string
@@ -59,4 +44,28 @@ func TestEventfLogMetadataProvider(t *testing.T) {
 
 	e := Eventf(CriticalSeverity, nil, "foo: %v", param)
 	assert.EqualValues(t, param, e.Metadata)
+}
+
+func BenchmarkLogMetadataInterface(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		Eventf(ErrorSeverity, nil, "foo", map[string]interface{}{
+			"string": "foo",
+			"number": 42,
+		})
+	}
+}
+
+func BenchmarkLogMetadataStrings(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		Eventf(ErrorSeverity, nil, "foo", map[string]string{
+			"string": "foo",
+			"number": "42",
+		})
+	}
+}
+
+func BenchmarkLogMetadataInterpolated(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		Eventf(ErrorSeverity, nil, "foo %s %d", "foo", 42)
+	}
 }

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,7 @@ github.com/nu7hatch/gouuid v0.0.0-20131221200532-179d4d0c4d8d h1:VhgPp6v9qf9Agr/
 github.com/nu7hatch/gouuid v0.0.0-20131221200532-179d4d0c4d8d/go.mod h1:YUTz3bUH2ZwIWBy3CJBeOBEugqcmXREj14T+iG/4k4U=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=


### PR DESCRIPTION
This change introduces the concept of 'non-string metadata' to slog. There are two main reasons for doing this:

1. We wish to use non-string data in downstream systems. Our two current use cases for this are; sending errors to an error tracking system and indexing non-string metadata natively in elasticsearch (e.g. we want to be able to emit an array of tags).
2. Aligning the interface with expectations. We currently have multiple instances of incorrect internal uses where a `map[string]interface{}` is passed, and this metadata is currently silently dropped.

We choose to add a `RawMetadata` field to maintain backwards compatibility. We provide an invariant that anything in the `Metadata` map will be the equivalent stringified version of the value in ` RawMetadata`, as serialized by Go's native `Sprint` function.

The downsides to this are that we increase the memory footprint of a `slog.Event` and the allocations performed to log something. However, there are probably many optimisations that we can do to alleviate this if it becomes an issue. Here are some simple benchmarks for logging with 2 params.

Before
```
➜  slog git:(master) ✗ go test -bench . -benchmem  .
goos: darwin
goarch: amd64
pkg: github.com/monzo/slog
BenchmarkLogMetadataStrings-8        	 1000000	      1027 ns/op	     905 B/op	      11 allocs/op
BenchmarkLogMetadataInterpolated-8   	  766807	      1575 ns/op	     743 B/op	      13 allocs/op
PASS
```

After
```
➜  slog git:(will-slog-metadata) ✗ go test -bench . -benchmem  .
goos: darwin
goarch: amd64
pkg: github.com/monzo/slog
BenchmarkLogMetadataInterface-8      	  696866	      1439 ns/op	    1251 B/op	      15 allocs/op
BenchmarkLogMetadataStrings-8        	  897459	      1324 ns/op	    1277 B/op	      15 allocs/op
BenchmarkLogMetadataInterpolated-8   	  667189	      1621 ns/op	     743 B/op	      13 allocs/op
PASS
```