### PR TITLE
Add improved error metadata behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,22 @@ slog.Info(ctx, "Loading widget", map[string]interface{}{
 })
 ```
 
+### Errors
+
+`slog` also provides a shorthand for capturing errors in the form of:
+
+```go
+slog.Error(ctx, "Failed to load widget", err)
+```
+
+This is functionally equivalent to:
+
+```go
+slog.Error(ctx, "Failed to load widget", map[string]interface{}{
+    "error": err,
+})
+```
+
 ### Other uses
 
 For backwards-compatibility, slog accepts metadata in the form of `map[string]string`.

--- a/README.md
+++ b/README.md
@@ -34,6 +34,25 @@ slog.Error(ctx, "Failed to load widget", map[string]interface{}{
 })
 ```
 
+You may also add metadata to errors captured this way:
+
+```go
+slog.Error(ctx, "Failed to load widget", err, map[string]interface{}{
+    "user_id": 42,
+})
+```
+
+Which is equivalent to:
+
+```go
+slog.Error(ctx, "Failed to load widget", map[string]interface{}{
+    "error": err,
+    "user_id": 42,
+})
+```
+
+If an error is supplied, it will override any error key that is part of the metadata map.
+
 ### Other uses
 
 For backwards-compatibility, slog accepts metadata in the form of `map[string]string`.

--- a/event_test.go
+++ b/event_test.go
@@ -25,12 +25,6 @@ func TestEventMetadata(t *testing.T) {
 		params   []interface{}
 		expected map[string]interface{}
 	}{
-		// {
-		// 	desc: "Message with metadata",
-		// 	message: "test",
-		// 	params: []interface{}{},
-		// 	expected: map[string]interface{}{},
-		// },
 		{
 			desc:     "Message with no params",
 			message:  "test",

--- a/event_test.go
+++ b/event_test.go
@@ -18,32 +18,106 @@ func TestEventfNilContext(t *testing.T) {
 	}
 }
 
-func TestEventfMetadataParam(t *testing.T) {
-	metadata := map[string]string{
-		"foo": "foo",
+func TestEventMetadata(t *testing.T) {
+	testCases := []struct {
+		desc     string
+		message  string
+		params   []interface{}
+		expected map[string]interface{}
+	}{
+		// {
+		// 	desc: "Message with metadata",
+		// 	message: "test",
+		// 	params: []interface{}{},
+		// 	expected: map[string]interface{}{},
+		// },
+		{
+			desc:     "Message with no params",
+			message:  "test",
+			params:   nil,
+			expected: nil,
+		},
+		{
+			desc:     "Message with no metadata",
+			message:  "test %d",
+			params:   []interface{}{43},
+			expected: nil,
+		},
+		{
+			desc:    "Message with string metadata",
+			message: "test",
+			params: []interface{}{
+				map[string]string{
+					"foo": "bar",
+				},
+			},
+			expected: map[string]interface{}{
+				"foo": "bar",
+			},
+		},
+		{
+			desc:    "Message with interface metadata",
+			message: "test",
+			params: []interface{}{
+				map[string]interface{}{
+					"foo": 42,
+				},
+			},
+			expected: map[string]interface{}{
+				"foo": 42,
+			},
+		},
+		{
+			desc:    "map as format arg with metadata",
+			message: "foo: %v",
+			params: []interface{}{
+				map[string]string{
+					"bar": "bar",
+				},
+				map[string]string{
+					"foo": "foo",
+				},
+			},
+			expected: map[string]interface{}{
+				"foo": "foo",
+			},
+		},
+		{
+			desc:    "Message with special error case",
+			message: "test",
+			params:  []interface{}{assert.AnError},
+			expected: map[string]interface{}{
+				"error": assert.AnError,
+			},
+		},
+		{
+			desc:    "Message with special error case and metadata",
+			message: "test",
+			params: []interface{}{assert.AnError, map[string]interface{}{
+				"foo": "bar",
+			}},
+			expected: map[string]interface{}{
+				"error": assert.AnError,
+				"foo":   "bar",
+			},
+		},
+		{
+			desc:    "Message with error param and metadata",
+			message: "eaten by a grue: %v",
+			params: []interface{}{assert.AnError, map[string]interface{}{
+				"foo": "bar",
+			}},
+			expected: map[string]interface{}{
+				"foo": "bar",
+			},
+		},
 	}
-
-	param := map[string]string{
-		"bar": "bar",
+	for _, tC := range testCases {
+		t.Run(tC.desc, func(t *testing.T) {
+			e := Eventf(ErrorSeverity, nil, tC.message, tC.params...)
+			assert.EqualValues(t, tC.expected, e.Metadata)
+		})
 	}
-
-	e := Eventf(CriticalSeverity, nil, "foo: %v", param, metadata)
-	expected := map[string]interface{}{
-		"foo": "foo",
-	}
-	assert.EqualValues(t, expected, e.Metadata)
-}
-
-func TestEventfMetadataParamInterface(t *testing.T) {
-	metadata := map[string]interface{}{
-		"foo": 3,
-	}
-
-	e := Eventf(CriticalSeverity, nil, "foo", metadata)
-	expected := map[string]interface{}{
-		"foo": 3,
-	}
-	assert.EqualValues(t, expected, e.Metadata)
 }
 
 type testLogMetadataProvider map[string]string


### PR DESCRIPTION
This PR builds upon #4 by adding some conventions around errors. We are building the ability to forward errors to other systems, which necessitates defining some well-known key to store error data. 

We support reporting errors with `slog.Error(ctx, "something went wrong", err)` which attaches the error to the metadata in the `error` key, and passing metadata as well, with `slog.Error(ctx, "something went wrong", err, metadata)`.

This also preserves existing behaviour by only doing this when format strings are not passed in the message.
