### PR TITLE
[BP-391] Store error as a specific field on the slog event

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,14 +26,6 @@ slog.Info(ctx, "Loading widget", map[string]interface{}{
 slog.Error(ctx, "Failed to load widget", err)
 ```
 
-This is functionally equivalent to:
-
-```go
-slog.Error(ctx, "Failed to load widget", map[string]interface{}{
-    "error": err,
-})
-```
-
 You may also add metadata to errors captured this way:
 
 ```go
@@ -42,16 +34,7 @@ slog.Error(ctx, "Failed to load widget", err, map[string]interface{}{
 })
 ```
 
-Which is equivalent to:
-
-```go
-slog.Error(ctx, "Failed to load widget", map[string]interface{}{
-    "error": err,
-    "user_id": 42,
-})
-```
-
-If an error is supplied, it will override any error key that is part of the metadata map.
+Slog will pick up the first `error` it finds in the metadata and make it available in `event.Error`.
 
 ### Other uses
 

--- a/event_test.go
+++ b/event_test.go
@@ -1,6 +1,7 @@
 package slog
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -226,6 +227,15 @@ func TestEventMetadata(t *testing.T) {
 			assert.Equal(t, tC.expectedMessage, e.Message)
 		})
 	}
+}
+
+func TestEventfExtractsErrorParam(t *testing.T) {
+
+	err := errors.New("i'm an error")
+	e := Eventf(CriticalSeverity, nil, "foo: %s", err, map[string]interface{}{"foo": 42})
+	assert.Equal(t, "foo: i'm an error", e.Message)
+	assert.Equal(t, map[string]interface{}{"error": err, "foo": 42}, e.Metadata)
+	assert.Equal(t, err, e.Error)
 }
 
 type testLogMetadataProvider map[string]string


### PR DESCRIPTION
This will allow us to handle it differently to other metadata when logging, for example, pull out bits of information added to custom errors such as https://github.com/monzo/terrors