### PR TITLE
Add LeveledLogger interface, struct and mock

### DIFF
--- a/default.go
+++ b/default.go
@@ -36,7 +36,7 @@ func Critical(ctx context.Context, msg string, params ...interface{}) {
 	}
 }
 
-// Critical constructs a logging event with error severity, and sends it via the default Logger
+// Error constructs a logging event with error severity, and sends it via the default Logger
 func Error(ctx context.Context, msg string, params ...interface{}) {
 	if l := DefaultLogger(); l != nil {
 		l.Log(Eventf(ErrorSeverity, ctx, msg, params...))

--- a/logger.go
+++ b/logger.go
@@ -1,25 +1,61 @@
 package slog
 
+import "context"
+
 // A Logger is a way of outputting events.
 type Logger interface {
 	Log(evs ...Event)
 	Flush() error
 }
 
-// A MultiLogger sends invocations to multiple Loggers.
-type MultiLogger []Logger
+// LeveledLogger is a logger which logs at different levels.
+type LeveledLogger interface {
+	Critical(ctx context.Context, msg string, params ...interface{})
+	Error(ctx context.Context, msg string, params ...interface{})
+	Warn(ctx context.Context, msg string, params ...interface{})
+	Info(ctx context.Context, msg string, params ...interface{})
+	Debug(ctx context.Context, msg string, params ...interface{})
+	Trace(ctx context.Context, msg string, params ...interface{})
+}
 
-func (ls MultiLogger) Log(evs ...Event) {
-	for _, l := range ls {
-		l.Log(evs...)
+// SeverityLogger is a logger which can log at different severity levels.
+type SeverityLogger struct {
+	Logger
+}
+
+// NewSeverityLogger creates a SeverityLogger which wraps the default logger.
+func NewSeverityLogger() SeverityLogger {
+	return SeverityLogger{
+		Logger: DefaultLogger(),
 	}
 }
 
-func (ls MultiLogger) Flush() error {
-	for _, l := range ls {
-		if err := l.Flush(); err != nil {
-			return err
-		}
-	}
-	return nil
+// Critical writes a Critical event to the logger.
+func (s SeverityLogger) Critical(ctx context.Context, msg string, params ...interface{}) {
+	s.Log(Eventf(CriticalSeverity, ctx, msg, params...))
+}
+
+// Error writes a Error event to the logger.
+func (s SeverityLogger) Error(ctx context.Context, msg string, params ...interface{}) {
+	s.Log(Eventf(ErrorSeverity, ctx, msg, params...))
+}
+
+// Warn writes a Warn event to the logger.
+func (s SeverityLogger) Warn(ctx context.Context, msg string, params ...interface{}) {
+	s.Log(Eventf(WarnSeverity, ctx, msg, params...))
+}
+
+// Info writes a Info event to the logger.
+func (s SeverityLogger) Info(ctx context.Context, msg string, params ...interface{}) {
+	s.Log(Eventf(InfoSeverity, ctx, msg, params...))
+}
+
+// Debug writes a Debug event to the logger.
+func (s SeverityLogger) Debug(ctx context.Context, msg string, params ...interface{}) {
+	s.Log(Eventf(DebugSeverity, ctx, msg, params...))
+}
+
+// Trace writes a Trace event to the logger.
+func (s SeverityLogger) Trace(ctx context.Context, msg string, params ...interface{}) {
+	s.Log(Eventf(TraceSeverity, ctx, msg, params...))
 }

--- a/mock.go
+++ b/mock.go
@@ -1,0 +1,37 @@
+package slog
+
+import (
+	"context"
+
+	"github.com/stretchr/testify/mock"
+)
+
+type MockLogger struct {
+	mock.Mock
+}
+
+var _ LeveledLogger = &MockLogger{}
+
+func (m *MockLogger) Critical(ctx context.Context, msg string, params ...interface{}) {
+	m.Called(ctx, msg, params)
+}
+
+func (m *MockLogger) Error(ctx context.Context, msg string, params ...interface{}) {
+	m.Called(ctx, msg, params)
+}
+
+func (m *MockLogger) Warn(ctx context.Context, msg string, params ...interface{}) {
+	m.Called(ctx, msg, params)
+}
+
+func (m *MockLogger) Info(ctx context.Context, msg string, params ...interface{}) {
+	m.Called(ctx, msg, params)
+}
+
+func (m *MockLogger) Debug(ctx context.Context, msg string, params ...interface{}) {
+	m.Called(ctx, msg, params)
+}
+
+func (m *MockLogger) Trace(ctx context.Context, msg string, params ...interface{}) {
+	m.Called(ctx, msg, params)
+}

--- a/multi.go
+++ b/multi.go
@@ -1,0 +1,21 @@
+package slog
+
+// A MultiLogger sends invocations to multiple Loggers.
+type MultiLogger []Logger
+
+// Log the event to each sub-logger.
+func (ls MultiLogger) Log(evs ...Event) {
+	for _, l := range ls {
+		l.Log(evs...)
+	}
+}
+
+// Flush all sub-loggers.
+func (ls MultiLogger) Flush() error {
+	for _, l := range ls {
+		if err := l.Flush(); err != nil {
+			return err
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
This PR formalises the concept of `LeveledLogger` which provides logging at different severities. With the current usage of the default leveled functions, we can only capture/mock calls to the underlying interface. This makes it more cumbersome to test, in cases where we want to assert that a particular log happened without relying on global state.

We have Monzo internal cases where this global state is causing tests to flake, and this is the simplest solution to resolve those problems.