### PR TITLE
Add support for packing slog params into a context

### DIFF
--- a/context.go
+++ b/context.go
@@ -1,0 +1,47 @@
+package slog
+
+import "context"
+
+type contextKey string
+
+// we use a key here of an unexported type so that no code outside of this package
+// can access these params other than via the exported accessor funcs
+var slogParamsContextKey contextKey = "slog-params"
+
+// WithParams packs a map of slog params into a context.Context, overwriting
+// any previously packed params of the same key. These fields would also be
+// overwritten by any params of the same name in the actual slog.Info/Error/etc call.
+func WithParams(ctx context.Context, params map[string]string) context.Context {
+	p := ParamsFromContext(ctx)
+	p = mergeParams(p, params)
+
+	return context.WithValue(ctx, slogParamsContextKey, p)
+}
+
+// ParamsFromContext returns any slog params stored within the context, if no params
+// are found it will return a non-nil empty map
+func ParamsFromContext(ctx context.Context) map[string]string {
+	m, ok := ctx.Value(slogParamsContextKey).(map[string]string)
+	if !ok {
+		// return a non-nil map so we can still assign to it
+		// without checking for nil
+		return make(map[string]string)
+	}
+	return m
+}
+
+// mergeParams will merge map b into map a, overwriting any keys in a that overlap
+// with b
+func mergeParams(a, b map[string]string) map[string]string {
+	// take a copy of map A so we don't mutate the original map
+	copyA := make(map[string]string, len(a))
+	for k, v := range a {
+		copyA[k] = v
+	}
+	// write all keys from map b into our copy of a
+	for k, v := range b {
+		copyA[k] = v
+	}
+
+	return copyA
+}

--- a/event.go
+++ b/event.go
@@ -84,6 +84,7 @@ func Eventf(sev Severity, ctx context.Context, msg string, params ...interface{}
 	}
 
 	metadata := map[string]interface{}(nil)
+
 	var errParam error
 	if len(params) > 0 {
 
@@ -137,6 +138,12 @@ func Eventf(sev Severity, ctx context.Context, msg string, params ...interface{}
 			nonMetaParams := params[0:endIndex]
 			msg = fmt.Sprintf(msg, nonMetaParams...)
 		}
+	}
+
+	// if there is any metadata stored in the context, extract it and add to the metadata map
+	// any existing keys will be preserved in the metadata map
+	if contextMetadata := ParamsFromContext(ctx); len(contextMetadata) > 0 {
+		metadata = mergeMetadata(metadata, stringMapToInterfaceMap(contextMetadata))
 	}
 
 	event := Event{


### PR DESCRIPTION
Hello! long time no see, I hope you're well, how's the family?

I'm still using slog for some personal projects and I always found myself wishing I could pack slog params into a context to maintain params deep in a callstack without having to pass a map around everywhere, so here's a little PR to add that.

![](https://media.giphy.com/media/2Jl7a8ixNlNHa/giphy.gif)