### PR TITLE
Add the ability to send messages direct to implementations of LeveledLogger

### DIFF
--- a/default.go
+++ b/default.go
@@ -29,44 +29,86 @@ func Log(evs ...Event) {
 	}
 }
 
-// Critical constructs a logging event with critical severity, and sends it via the default Logger
+// Critical constructs a logging event with critical severity. If the
+// default Logger implements the LeveledLogger interface, we forward the
+// requests via the Critical interface function. If not, the event is sent
+// via the default Logger
 func Critical(ctx context.Context, msg string, params ...interface{}) {
 	if l := DefaultLogger(); l != nil {
-		l.Log(Eventf(CriticalSeverity, ctx, msg, params...))
+		if ll, ok := l.(LeveledLogger); ok {
+			ll.Critical(ctx, msg, params...)
+		} else {
+			l.Log(Eventf(CriticalSeverity, ctx, msg, params...))
+		}
 	}
 }
 
-// Error constructs a logging event with error severity, and sends it via the default Logger
+// Error constructs a logging event with error severity. If the
+// default Logger implements the LeveledLogger interface, we forward the
+// requests via the Error interface function. If not, the event is sent
+// via the default Logger
 func Error(ctx context.Context, msg string, params ...interface{}) {
 	if l := DefaultLogger(); l != nil {
-		l.Log(Eventf(ErrorSeverity, ctx, msg, params...))
+		if ll, ok := l.(LeveledLogger); ok {
+			ll.Error(ctx, msg, params...)
+		} else {
+			l.Log(Eventf(ErrorSeverity, ctx, msg, params...))
+		}
 	}
 }
 
-// Warn constructs a logging event with warn severity, and sends it via the default Logger
+// Warn constructs a logging event with warn severity. If the
+// DefaultLogger implements the LeveledLogger interface, we forward the
+// requests via the Warn interface function. If not, the event is sent
+// via the default Logger
 func Warn(ctx context.Context, msg string, params ...interface{}) {
 	if l := DefaultLogger(); l != nil {
-		l.Log(Eventf(WarnSeverity, ctx, msg, params...))
+		if ll, ok := l.(LeveledLogger); ok {
+			ll.Warn(ctx, msg, params...)
+		} else {
+			l.Log(Eventf(WarnSeverity, ctx, msg, params...))
+		}
 	}
 }
 
-// Info constructs a logging event with info severity, and sends it via the default Logger
+// Info constructs a logging event with info severity. If the
+// default Logger implements the LeveledLogger interface, we forward the
+// requests via the Info interface function. If not, the event is sent
+// via the default Logger
 func Info(ctx context.Context, msg string, params ...interface{}) {
 	if l := DefaultLogger(); l != nil {
-		l.Log(Eventf(InfoSeverity, ctx, msg, params...))
+		if ll, ok := l.(LeveledLogger); ok {
+			ll.Info(ctx, msg, params...)
+		} else {
+			l.Log(Eventf(InfoSeverity, ctx, msg, params...))
+		}
 	}
 }
 
-// Debug constructs a logging event with debug severity, and sends it via the default Logger
+// Debug constructs a logging event with debug severity. If the
+// default Logger implements the LeveledLogger interface, we forward the
+// requests via the Debug interface function. If not, the event is sent
+// via the default Logger
 func Debug(ctx context.Context, msg string, params ...interface{}) {
 	if l := DefaultLogger(); l != nil {
-		l.Log(Eventf(DebugSeverity, ctx, msg, params...))
+		if ll, ok := l.(LeveledLogger); ok {
+			ll.Debug(ctx, msg, params...)
+		} else {
+			l.Log(Eventf(DebugSeverity, ctx, msg, params...))
+		}
 	}
 }
 
-// Trace constructs a logging event with trace severity, and sends it via the default Logger
+// Trace constructs a logging event with trace severity. If the
+// default Logger implements the LeveledLogger interface, we forward the
+// requests via the Trace interface function. If not, the event is sent
+// via the default Logger
 func Trace(ctx context.Context, msg string, params ...interface{}) {
 	if l := DefaultLogger(); l != nil {
-		l.Log(Eventf(TraceSeverity, ctx, msg, params...))
+		if ll, ok := l.(LeveledLogger); ok {
+			ll.Trace(ctx, msg, params...)
+		} else {
+			l.Log(Eventf(TraceSeverity, ctx, msg, params...))
+		}
 	}
 }


### PR DESCRIPTION
This change allows us to solve a problem where slog.Trace and slog.Debug are used in hot paths but the messages end up being dropped by the backing Logger implementation. This means we have to pay a current performance penalty augmenting the log message which can be substantial in a hot loop.

This change allows us to find implementations of LeveledLogger as part of the DefaultLogger and send messages directly to the LeveledLogger.

This can power optimisations like the backing implementation deciding to drop messages based on severity or context values without going through the performance penalty of augmenting the log messages prior