### PR TITLE
Add `FromErrorLogger` to allow us to set the severity from the error

### DIFF
--- a/default.go
+++ b/default.go
@@ -112,3 +112,14 @@ func Trace(ctx context.Context, msg string, params ...interface{}) {
 		}
 	}
 }
+
+func FromError(ctx context.Context, msg string, err error, params ...interface{}) {
+	if l := DefaultLogger(); l != nil {
+		params = []interface{}{err, params}
+		if ll, ok := l.(FromErrorLogger); ok {
+			ll.FromError(ctx, msg, err, params...)
+		} else {
+			l.Log(Eventf(ErrorSeverity, ctx, msg, params...))
+		}
+	}
+}

--- a/default.go
+++ b/default.go
@@ -113,6 +113,10 @@ func Trace(ctx context.Context, msg string, params ...interface{}) {
 	}
 }
 
+// FromError constructs a logging event with error severity by default.
+// If the default Logger implements the FromErrorLogger interface, we
+// forward the requests via the FromError interface function. In this
+// case the severity will be inferred from the error.
 func FromError(ctx context.Context, msg string, err error, params ...interface{}) {
 	if l := DefaultLogger(); l != nil {
 		params = []interface{}{err, params}

--- a/default_test.go
+++ b/default_test.go
@@ -96,7 +96,7 @@ func TestNilDefaultLogger(t *testing.T) {
 	Warn(context.Background(), "Important warn message", "foo")
 	Error(context.Background(), "Important error message", "foo")
 	Critical(context.Background(), "Important critical message", "foo")
-	FromError(context.Background(), "Important critical message", context.Canceled, "foo")
+	FromError(context.Background(), "Important from error message", context.Canceled, "foo")
 }
 
 // testLogLeveledLogger implements the Logger interface

--- a/logger.go
+++ b/logger.go
@@ -18,6 +18,12 @@ type LeveledLogger interface {
 	Trace(ctx context.Context, msg string, params ...interface{})
 }
 
+// FromErrorLogger is a logger which logs errors.
+// The severity of the log is inferred from the error.
+type FromErrorLogger interface {
+	FromError(ctx context.Context, msg string, err error, params ...interface{})
+}
+
 // SeverityLogger is a logger which can log at different severity levels.
 type SeverityLogger struct {
 	Logger


### PR DESCRIPTION
In this change we add a `FromErrorLogger` interface and `FromError` function which lets us determine the severity of the slog from the error passed in. This is useful to prioritise errors that are swallowed. We are likely less interested in a context canceled error versus an application error that signals a bug in our logic.