### PR TITLE
feat: add support for storing metadata params in the context

### DIFF
--- a/clone_go1.21.go
+++ b/clone_go1.21.go
@@ -1,0 +1,11 @@
+//go:build go1.21
+// +build go1.21
+
+package slog
+
+import "maps"
+
+// cloneStringMap wraps maps.Clone on Go 1.21 and newer.
+func cloneStringMap(m map[string]string) map[string]string {
+	return maps.Clone(m)
+}

--- a/clone_polyfill.go
+++ b/clone_polyfill.go
@@ -1,0 +1,20 @@
+//go:build !go1.21
+// +build !go1.21
+
+package slog
+
+// cloneStringMap provides a polyfill for maps.Clone on Go 1.20 and older.
+//
+// This implementation is not as efficient as the built-in implementation (which uses
+// runtime.clone internally).
+func cloneStringMap(m map[string]string) map[string]string {
+	if m == nil {
+		return m
+	}
+
+	res := make(map[string]string, len(m))
+	for k, v := range m {
+		res[k] = v
+	}
+	return res
+}

--- a/event.go
+++ b/event.go
@@ -139,6 +139,13 @@ func Eventf(sev Severity, ctx context.Context, msg string, params ...interface{}
 		}
 	}
 
+	// If there are any metadata params stashed in the context, merge them into the
+	// metadata. We do this after processing all params passed directly to Eventf so
+	// that they take precedence.
+	if ctxMetadata := Params(ctx); len(ctxMetadata) > 0 {
+		metadata = mergeMetadata(metadata, stringMapToInterfaceMap(ctxMetadata))
+	}
+
 	event := Event{
 		Context:         ctx,
 		Id:              id.String(),

--- a/event_test.go
+++ b/event_test.go
@@ -239,6 +239,22 @@ func TestEventMetadata(t *testing.T) {
 	}
 }
 
+func Test_InlineParamsTakePrecedenceOverContextParams(t *testing.T) {
+	ctx := WithParams(context.Background(), map[string]string{
+		"key1": "value_to_be_shadowed",
+		"key2": "other_value",
+	})
+
+	e := Eventf(ErrorSeverity, ctx, "test message", map[string]string{
+		"key1": "value",
+	})
+
+	assert.Equal(t, map[string]any{
+		"key1": "value",
+		"key2": "other_value",
+	}, e.Metadata)
+}
+
 type testLogMetadataProvider map[string]string
 
 func (p testLogMetadataProvider) LogMetadata() map[string]string {

--- a/event_test.go
+++ b/event_test.go
@@ -249,7 +249,7 @@ func Test_InlineParamsTakePrecedenceOverContextParams(t *testing.T) {
 		"key1": "value",
 	})
 
-	assert.Equal(t, map[string]any{
+	assert.Equal(t, map[string]interface{}{
 		"key1": "value",
 		"key2": "other_value",
 	}, e.Metadata)

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,15 @@
 module github.com/monzo/slog
 
-go 1.13
+go 1.18
 
 require (
 	github.com/nu7hatch/gouuid v0.0.0-20131221200532-179d4d0c4d8d
 	github.com/stretchr/testify v1.4.0
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/stretchr/objx v0.1.0 // indirect
+	gopkg.in/yaml.v2 v2.2.2 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -1,15 +1,8 @@
 module github.com/monzo/slog
 
-go 1.18
+go 1.13
 
 require (
 	github.com/nu7hatch/gouuid v0.0.0-20131221200532-179d4d0c4d8d
 	github.com/stretchr/testify v1.4.0
-)
-
-require (
-	github.com/davecgh/go-spew v1.1.0 // indirect
-	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/stretchr/objx v0.1.0 // indirect
-	gopkg.in/yaml.v2 v2.2.2 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,7 @@ github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/params.go
+++ b/params.go
@@ -2,7 +2,6 @@ package slog
 
 import (
 	"context"
-	"maps"
 	"sync"
 	"testing"
 )
@@ -76,7 +75,7 @@ func (n *paramNode) params() params {
 		// mutate it without impacting other callers (and potentially causing panics if
 		// the map is mutated concurrently). This trades off a small amount of performance
 		// and memory usage for safety.
-		return maps.Clone(n.mergedParams)
+		return cloneStringMap(n.mergedParams)
 	}
 
 	// NOTE: we could propagate length hints down the parent chain in order to pass a
@@ -89,7 +88,7 @@ func (n *paramNode) params() params {
 	// Cache the result for future requests
 	n.mergedParams = result
 
-	return maps.Clone(result) // As above, we return a copy to allow safe mutation
+	return cloneStringMap(result) // As above, we return a copy to allow safe mutation
 }
 
 func (n *paramNode) collectAllParams(dst params) {

--- a/params.go
+++ b/params.go
@@ -1,0 +1,158 @@
+package slog
+
+import (
+	"context"
+	"maps"
+	"sync"
+	"testing"
+)
+
+// WithParams returns a copy of the parent context containing the given log parameters.
+// Any log events generated using the returned context will include these parameters
+// as metadata.
+//
+// For example:
+//
+//	 ctx := slog.WithParams(ctx, map[string]string{
+//	   "foo_id": fooID,
+//	   "bar_id": barID,
+//	 })
+//
+//	slog.Info(ctx, "Linking foo to bar")  // includes foo_id and bar_id parameters
+//
+// If the parent context already contains parameters set by a previous call to WithParams,
+// the new parameters will be merged with the existing set, with newer values taking
+// precedence over older ones.
+//
+// It is not safe to modify the supplied map after passing it to WithParams.
+func WithParams(parent context.Context, params map[string]string) context.Context {
+	return context.WithValue(parent, contextKeyParamNode{}, &paramNode{
+		Parent:      parent,
+		ChildParams: params,
+	})
+}
+
+// WithParam is shorthand for calling WithParams with a single key-value pair.
+func WithParam(ctx context.Context, key, value string) context.Context {
+	return WithParams(ctx, params{key: value})
+}
+
+// Params returns all parameters stored in the given context using WithParams. This
+// function is intended to be used by libraries _other_ than slog that want access to the
+// set of parameters (i.e. `monzo/terrors` functions).
+//
+// The return value is guaranteed to be non-nil and can be safely mutated by the caller.
+func Params(ctx context.Context) map[string]string {
+	paramNode := paramNodeFromContext(ctx)
+	if paramNode == nil {
+		return map[string]string{}
+	}
+	return paramNode.params()
+}
+
+type params map[string]string
+
+type paramNode struct {
+	// Parent and ChildParams are the original values passed to slog.WithParams. The
+	// complete set of parameters for this node are determined by collecting any
+	// parameters already contained in Parent and then merging that with ChildParams.
+	//
+	// NOTE: this collection happens lazily when the params are queried, at which point
+	// we also cache the result in mergedParams to avoid repeating this work.
+	Parent      context.Context
+	ChildParams params
+
+	mergedParams    params
+	mergedParamsMtx sync.RWMutex
+}
+
+func (n *paramNode) params() params {
+	n.mergedParamsMtx.Lock()
+	defer n.mergedParamsMtx.Unlock()
+
+	// If we've already flattened the params, we can return those directly
+	if n.mergedParams != nil {
+		// NOTE: we return a _copy_ of the cached map here to allow the caller to safely
+		// mutate it without impacting other callers (and potentially causing panics if
+		// the map is mutated concurrently). This trades off a small amount of performance
+		// and memory usage for safety.
+		return maps.Clone(n.mergedParams)
+	}
+
+	// NOTE: we could propagate length hints down the parent chain in order to pass a
+	// more accurate capacity hint here, but the minimum size of a map already takes up
+	// to 8 K/V pairs without needing to allocate more buckets so in practice it doesn't
+	// matter much anyway.
+	result := make(params, len(n.ChildParams))
+	n.collectAllParamsAssumingReadLock(result)
+
+	// Cache the result for future requests
+	n.mergedParams = result
+
+	return maps.Clone(result) // As above, we return a copy to allow safe mutation
+}
+
+func (n *paramNode) collectAllParams(dst params) {
+	n.mergedParamsMtx.RLock()
+	defer n.mergedParamsMtx.RUnlock()
+	n.collectAllParamsAssumingReadLock(dst)
+}
+
+func (n *paramNode) collectAllParamsAssumingReadLock(res params) {
+	// If we've already cached the flattened params for this node, we can accumulate from
+	// those directly, avoiding potentially needing to traverse the parent chain to
+	// collect all params
+	if n.mergedParams != nil {
+		for k, v := range n.mergedParams {
+			res[k] = v
+		}
+		return
+	}
+
+	// Collect params from the parent node first (if it exists)
+	if parentNode := paramNodeFromContext(n.Parent); parentNode != nil {
+		parentNode.collectAllParams(res)
+	}
+
+	// Then merge the child params, overwriting any existing bindings for a given
+	// parameter key so that more recent calls to WithParams take precedence.
+	for k, v := range n.ChildParams {
+		res[k] = v
+	}
+
+	// NOTE: here we intentionally _don't_ cache the result in this paramNode because
+	// doing so would require us to clone the map, making our overall memory usage O(n^2)
+	// in the length of the paramNode chain. The trade-off is that we may redundantly
+	// re-traverse the parent chain collecting parameters in some use-cases (i.e. if
+	// there is a very long parent chain with many leaf nodes at the bottom, and we query
+	// parameters for each of the leaf nodes separately).
+}
+
+type contextKeyParamNode struct{}
+
+func paramNodeFromContext(ctx context.Context) *paramNode {
+	if ctx == nil {
+		return nil
+	}
+
+	stackAny := ctx.Value(contextKeyParamNode{})
+	if stackAny == nil {
+		return nil
+	}
+
+	stack, ok := stackAny.(*paramNode)
+	if !ok {
+		// This should never happen, and would typically indicate a bug in this library.
+		// If it happens in a test case we panic to ensure the failure isn't silently
+		// occurring in unit tests, otherwise we just log loudly.
+		errMsg := "internal error: slog.paramNodeFromContext: context value is not a *paramNode"
+		if testing.Testing() {
+			panic(errMsg)
+		} else {
+			Critical(context.Background(), errMsg)
+			return nil
+		}
+	}
+
+	return stack
+}

--- a/params.go
+++ b/params.go
@@ -38,7 +38,7 @@ func WithParam(ctx context.Context, key, value string) context.Context {
 
 // Params returns all parameters stored in the given context using WithParams. This
 // function is intended to be used by libraries _other_ than slog that want access to the
-// set of parameters (i.e. `monzo/terrors` functions).
+// set of parameters (e.g. `monzo/terrors` functions).
 //
 // The return value is guaranteed to be non-nil and can be safely mutated by the caller.
 func Params(ctx context.Context) map[string]string {
@@ -57,7 +57,8 @@ type paramNode struct {
 	// parameters already contained in Parent and then merging that with ChildParams.
 	//
 	// NOTE: this collection happens lazily when the params are queried, at which point
-	// we also cache the result in mergedParams to avoid repeating this work.
+	// we also cache the result in mergedParams to avoid repeating this work. We don't
+	// do this upfront to avoid unnecessary work if the params are never queried.
 	Parent      context.Context
 	ChildParams params
 

--- a/params_test.go
+++ b/params_test.go
@@ -1,0 +1,106 @@
+package slog
+
+import (
+	"context"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func Test_Params(t *testing.T) {
+	t.Run("Params is empty by default", func(t *testing.T) {
+		emptyParams := Params(context.Background())
+		require.NotNil(t, emptyParams)
+		require.Empty(t, emptyParams)
+	})
+
+	t.Run("Params does not panic on nil context", func(t *testing.T) {
+		assert.Empty(t, Params(nil))
+	})
+
+	t.Run("Params returns a map that can be mutated", func(t *testing.T) {
+		ctx := WithParams(context.Background(), map[string]string{"key": "value"})
+
+		heldParams := Params(ctx)
+		heldParams["key"] = "new_value"
+
+		// The original context should not be affected by our mutation
+		assert.Equal(t, map[string]string{"key": "value"}, Params(ctx))
+	})
+}
+
+func Test_WithParams(t *testing.T) {
+	t.Run("single use of WithParams", func(t *testing.T) {
+		// WithParams returns a new context containing the params
+		ctx1 := context.Background()
+		ctx2 := WithParams(ctx1, map[string]string{"key": "value"})
+		assert.Empty(t, ctx1)
+		assert.Equal(t, map[string]string{"key": "value"}, Params(ctx2))
+	})
+
+	t.Run("multiple calls to WithParams", func(t *testing.T) {
+		ctx1 := context.Background()
+		ctx2 := WithParams(ctx1, map[string]string{"key1": "value1"})
+		ctx3 := WithParams(ctx2, map[string]string{"key2": "value2"})
+		assert.Empty(t, ctx1)
+		assert.Equal(t, map[string]string{"key1": "value1"}, Params(ctx2))
+		assert.Equal(t, map[string]string{"key1": "value1", "key2": "value2"}, Params(ctx3))
+	})
+
+	t.Run("later values take precedence", func(t *testing.T) {
+		ctx1 := context.Background()
+		ctx2 := WithParams(ctx1, map[string]string{"key": "value1"})
+		ctx3 := WithParams(ctx2, map[string]string{"key": "value2"})
+		assert.Empty(t, ctx1)
+		assert.Equal(t, map[string]string{"key": "value1"}, Params(ctx2))
+		assert.Equal(t, map[string]string{"key": "value2"}, Params(ctx3))
+	})
+}
+
+func Benchmark_WithParams(b *testing.B) {
+	ctx := context.Background()
+	for i := 0; i < b.N; i++ {
+		_ = WithParams(ctx, map[string]string{
+			"k1": "v1",
+			"k2": "v2",
+			"k3": "v3",
+		})
+	}
+}
+
+func Benchmark_WithParam(b *testing.B) {
+	ctx := context.Background()
+	for i := 0; i < b.N; i++ {
+		ctx := WithParam(ctx, "k1", "v1")
+		ctx = WithParam(ctx, "k2", "v2")
+		_ = WithParam(ctx, "k3", "v3")
+	}
+}
+
+func Benchmark_Params_Uncached(b *testing.B) {
+	contexts := make([]context.Context, b.N)
+	for i := 0; i < b.N; i++ {
+		ctx := context.Background()
+		ctx = WithParam(ctx, "k1", "v1")
+		ctx = WithParam(ctx, "k2", "v2")
+		ctx = WithParam(ctx, "k3", "v3")
+		contexts[i] = ctx
+	}
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		_ = Params(contexts[i])
+	}
+}
+
+func Benchmark_Params_Cached(b *testing.B) {
+	ctx := context.Background()
+	ctx = WithParam(ctx, "k1", "v1")
+	ctx = WithParam(ctx, "k2", "v2")
+	ctx = WithParam(ctx, "k3", "v3")
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		_ = Params(ctx)
+	}
+}


### PR DESCRIPTION
This PR adds three new functions to this library for propagating metadata params via `context.Context` values, as an alternative to explicitly passing `map[string]string` values to individual log lines:

```go
// Writing params to context
func WithParams(parent context.Context, params map[string]string) context.Context
func WithParam(ctx context.Context, key, value string) context.Context

// Reading params from context
func Params(ctx context.Context) map[string]string
```

(See the implementation itself for more extensive documentation of these functions.)

---

### ✨  Design decisions

- **naming of these functions**. I've named the concept of metadata parameters "Params" — not "Metadata" or "MetadataParams" — because this is what these are called in practice in our internal Monzo monorepo. This slightly conflates the concept of "params" being passed to slog functions (since these functions _also_ take formatting operands as parameters), but I consider that worthwhile in staying consistent with our existing `slog` callsites.

- **use of `map[string]string` rather than `map[string]any`**. The standard `slog` functions based on `slog.Eventf` support taking metadata parameters with the more general type `map[string]any`. The new "Param" functions enforce `map[string]string`, mostly for compatibility with [terrors metadata](https://github.com/monzo/terrors) which must be of this type. i.e. this type allows `slog.Params(ctx)` to be straightforwardly used as error metadata as well as log metadata.

### 🛠️  Implementation

The implementation is fairly readable and thoroughly documented, but at a high level:
- **`slog.WithParam(s)`**. On the write path, we use `context.WithValue` to store a pointer to a `paramNode` value that is effectively a linked-list of `map[string]string` values added in successive calls to `slog.WithParam(s)`. This is always a fast O(1) operation.
- **`slog.Params(ctx)`**. On the read path, we traverse the linked list from its root accumulating the full set of metadata parameters, then cache the result in the leaf node. This requires taking a write lock on the leaf and read locks on the internal node, but means that subsequent calls to `slog.Params` with the same `ctx` will be fast (i.e. only need to clone the cached map before returning it).

```go
type paramNode struct {
	// Parent and ChildParams are the original values passed to slog.WithParams. The
	// complete set of parameters for this node are determined by collecting any
	// parameters already contained in Parent and then merging that with ChildParams.
	//
	// NOTE: this collection happens lazily when the params are queried, at which point
	// we also cache the result in mergedParams to avoid repeating this work.
	Parent      context.Context
	ChildParams params

	mergedParams    params
	mergedParamsMtx sync.RWMutex
}
```